### PR TITLE
New checkbox icons were added to FilterView

### DIFF
--- a/Components/Sources/Components/CheckmarkView.swift
+++ b/Components/Sources/Components/CheckmarkView.swift
@@ -8,14 +8,9 @@
 
 import SwiftUI
 import Palette
+import Icons
 
 public struct CheckmarkView: View {
-    
-    // MARK: - Nested types
-    
-    enum Constants {
-        static let ratio: CGFloat = 0.2
-    }
     
     // MARK: - States
     
@@ -57,20 +52,19 @@ public struct CheckmarkView: View {
     public var body: some View {
         ZStack {
             if isFilled {
-                Circle()
-                    .foregroundColor(Color.backround(isSelected: isSelected))
-                    .overlay(
-                        Circle()
-                            .stroke(Color.border(isSelected: isSelected), lineWidth: 1)
-                    )
-                    .padding(.zero)
+                Circle().stroke(Color.border(isSelected: isSelected), lineWidth: 1)
             }
             
             if isSelected {
-                Image(systemName: "checkmark")
-                    .resizable()
-                    .foregroundColor(Color.foreground(isFilled: isFilled))
-                    .padding(maxSize.width * Constants.ratio)
+                if isFilled {
+                    Icons.checkmarkCircleFill.image
+                        .resizable()
+                } else {
+                    Icons.checkmark.image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: maxSize.width * 0.7)
+                }
             }
         }
         .frame(width: maxSize.width, height: maxSize.height)
@@ -89,14 +83,6 @@ struct CheckmarkView_Previews: PreviewProvider {
 // MARK: - Colors
 
 fileprivate extension Color {
-    
-    static func foreground(isFilled: Bool) -> Color {
-        isFilled ? .white : Palette.main
-    }
-    
-    static func backround(isSelected: Bool) -> Color {
-        isSelected ? Palette.main : .clear
-    }
     
     static func border(isSelected: Bool) -> Color {
         isSelected ? Palette.main : Palette.telegrey

--- a/Icons/Sources/Icons/Icons.xcassets/checkmark.circle.fill.imageset/Contents.json
+++ b/Icons/Sources/Icons/Icons.xcassets/checkmark.circle.fill.imageset/Contents.json
@@ -10,6 +10,6 @@
     "version" : 1
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "original"
   }
 }

--- a/Icons/Sources/Icons/Icons.xcassets/checkmark.imageset/Contents.json
+++ b/Icons/Sources/Icons/Icons.xcassets/checkmark.imageset/Contents.json
@@ -10,6 +10,6 @@
     "version" : 1
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "original"
   }
 }


### PR DESCRIPTION
# Description
Checkbox icons from Icons were added to FilterView. Accessibility is also supported.

# How has this been tested?
Open FilterView by tap on button "Filters" on HomeFlow.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes