### PR TITLE
Feature/41 add highlightr for the markdown.code block view

### DIFF
--- a/Components/Package.swift
+++ b/Components/Package.swift
@@ -14,9 +14,10 @@ let package = Package(
         .package(path: "../Icons"),
         .package(path: "../Common"),
         .package(path: "../Markdown"),
-        .package(path: "../AppScript")
+        .package(path: "../AppScript"),
+        .package(url: "https://github.com/raspu/Highlightr.git", .revision("93199b9e434f04bda956a613af8f571933f9f037"))
     ],
     targets: [
-        .target(name: "Components", dependencies: ["Palette", "Markdown", "AppScript", "Icons", "Common"])
+        .target(name: "Components", dependencies: ["Palette", "Markdown", "AppScript", "Icons", "Common", "Highlightr"])
     ]
 )

--- a/Components/Sources/Components/MarkdownPostView/Blocks/CodeBlockView/CodeBlockView.swift
+++ b/Components/Sources/Components/MarkdownPostView/Blocks/CodeBlockView/CodeBlockView.swift
@@ -21,20 +21,20 @@ extension Markdown {
         // MARK: - View
         
         var body: some View {
-            if case let .codeBlock(_, code) = unit.type {
-                content(code: code)
+            switch unit.type {
+            case let .codeBlock(codeType, code):
+                content(codeType: codeType, code: code)
+            default:
+                EmptyView()
             }
         }
         
         // MARK: - View methods
         
-        func content(code: String) -> some View {
+        func content(codeType: String?, code: String) -> some View {
             ScrollView(.horizontal, showsIndicators: true) {
                 VStack(alignment: .center, spacing: .zero) {
-                    Text(code)
-                        .font(.custom("Menlo-Regular", size: 13))
-                        .foregroundColor(.foreground)
-                        .fixedSize(horizontal: false, vertical: true)
+                    CodeView(codeType: codeType, code: code)
                 }
             }
             .padding([.leading, .top, .trailing], 12)

--- a/Components/Sources/Components/MarkdownPostView/Blocks/CodeBlockView/CodeView.swift
+++ b/Components/Sources/Components/MarkdownPostView/Blocks/CodeBlockView/CodeView.swift
@@ -1,0 +1,97 @@
+//
+//  CodeView.swift
+//  StackOv (Components module)
+//
+//  Created by Илья Князьков
+//  Copyright © 2021 Erik Basargin. All rights reserved.
+//
+
+import SwiftUI
+import Highlightr
+
+struct CodeView: UIViewRepresentable {
+
+    // MARK: - Nested types
+
+    private enum Constants {
+        static let codeFont = UIFont.init(name: "Menlo-Regular", size: 13)
+    }
+
+    typealias UIViewType = UITextView
+
+    // MARK: - Private properties
+
+    private let codeType: String?
+    private let code: String
+    private var textStorage = CodeAttributedString()
+
+    // MARK: - Initialization
+
+    init(codeType: String?, code: String) {
+        self.codeType = codeType
+        self.code = code
+    }
+
+    // MARK: - View
+
+    func makeUIView(context: Context) -> UITextView {
+        let (textContainer, layoutManager) = getTextContainerAndLayoutManager()
+
+        textStorage.language = codeType?.lowercased()
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        return getTextView(with: code, container: textContainer)
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) { }
+
+    // MARK: - Private properties
+
+    private func getTextView(with text: String, container: NSTextContainer) -> UITextView {
+        let textView = UITextView(frame: .zero, textContainer: container)
+        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        textView.autocorrectionType = .no
+        textView.autocapitalizationType = .none
+        textView.font = Constants.codeFont
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.dataDetectorTypes = .all
+        textView.backgroundColor = .clear
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.text = text
+        return textView
+    }
+
+    private func getTextContainerAndLayoutManager() -> (container: NSTextContainer, manager: NSLayoutManager) {
+        let textContainer = NSTextContainer(size: .zero)
+        textContainer.lineFragmentPadding = .zero
+
+        let layoutManager = NSLayoutManager()
+
+
+        return (textContainer, layoutManager)
+    }
+}
+
+// MARK: - Previews
+
+struct CodeView_Previews: PreviewProvider {
+
+    static let code = ("""
+    func convertHtml() -> NSAttributedString {
+        guard let data = data(using: .utf8) else { return NSAttributedString() }
+        if let attributedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil) {
+            return attributedString
+        } else {
+            return NSAttributedString()
+        }
+    }
+    """)
+    static let codeType = "swift"
+
+    static var previews: some View {
+        CodeView(codeType: codeType, code: code)
+    }
+}
+

--- a/StackOv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StackOv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "Highlightr",
+        "repositoryURL": "https://github.com/raspu/Highlightr.git",
+        "state": {
+          "branch": null,
+          "revision": "93199b9e434f04bda956a613af8f571933f9f037",
+          "version": null
+        }
+      },
+      {
         "package": "Kingfisher",
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {


### PR DESCRIPTION
<!--
Please, do not forget to provide the next reviewers: Puasonych, erorrov, somenkovnikita, Blissfulman, and Stampoo.

Please, do not forget to mark this pull request with the labels of type of changes:
- feature|documentation
- bug
- hotfix
- service task
-->
# Description
<!-- 
Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

- Add Highlightr dependence  for highlight code depends on syntax
- Add CodeView with implement Highlightr

# How has this been tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Build and run app, move to detail question, code highlight with depends on syntax (see tag on question) and rule at this JS library https://highlightjs.org/static/demo/ 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# What to look for?

- Library does not have automatic detect language

---
<!-- Please include which issues are fixed/closed, if this is needed -->
Closes #41
